### PR TITLE
Fix bug on resposnse

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "start": "nodemon server/bin/www.js --exec babel-node",
-    "test": "cross-env NODE_ENV=test nyc mocha --require babel-core/register server/test/**/*.js --timeout 6000ms",
+    "test": "cross-env NODE_ENV=test nyc mocha --require babel-core/register server/test/**/*.js --exit",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "repository": {

--- a/server/controllers/quesController.js
+++ b/server/controllers/quesController.js
@@ -48,7 +48,7 @@ class QuesController {
     const newQues = questions.find(ques => ques.title === req.body.title && ques.text === req.body.text);
 
     if (req.body.title === '' || req.body.text === '') {
-      return res.status(204).json({
+      return res.status(400).json({
         status: 'fail',
         data: {
           message: 'Please fill in the fields',
@@ -73,7 +73,7 @@ class QuesController {
     };
 
     if (answer.text === '') {
-      return res.status(204).json({
+      return res.status(400).json({
         status: 'fail',
         message: 'Please provide an answer before sending',
       });

--- a/server/test/routes/apiroutes.test.js
+++ b/server/test/routes/apiroutes.test.js
@@ -74,7 +74,7 @@ describe('POST questions', () => {
     }
   })
 
-  it('Should return 204 (No Content) if a POST is sent with a blank request body', async () => {
+  it('Should return 400(Bad Request) if a POST is sent with a blank request body', async () => {
     try {
       const res = await chai.request(app)
       .post('/api/v1/questions')
@@ -83,7 +83,7 @@ describe('POST questions', () => {
         title: 'How to use css',
         text: '',
       })
-      res.should.have.status(204);
+      res.should.have.status(400);
     } catch(e) {
       throw e.message;
     }
@@ -126,11 +126,11 @@ describe('POST answers to a specific question', () => {
     }
   })
 
-  it('Should return 204(No Content answer is posted with an empty field', () => {
+  it('Should return 400(Bad Request) answer is posted with an empty field', () => {
     try {
       const wrongReq = mockReq(badRequest);
       QuesController.postAns(wrongReq, res);
-      res.status.should.have.been.calledWith(204);
+      res.status.should.have.been.calledWith(400);
     } catch (e) {
       throw e.message;
     }


### PR DESCRIPTION
### What does this PR do?
> It fixes the bug found when getting a response on POST routes
#### Description of Task to be completed?
> The response on the POST a question and a POST an answer, currently returns nothing and a status code of 204(No Content), Fix this, by making returning a 400(Bad Request).
#### How should this be manually tested?
> On postman send a POST request to `http://localhost:3000/api/v1/questions/2/answers`
#### What are the relevant pivotal tracker stories?
> [Fixed #159854930]